### PR TITLE
Handles but does not fix duplicate records

### DIFF
--- a/config.py
+++ b/config.py
@@ -39,4 +39,6 @@ FIELDS = [
     {"amanda": "cip_project_manager", "knack": "field_341"},
     {"amanda": "cip_id_number", "knack": "field_337"},
     {"amanda": "stampuser", "knack": "field_316"},
+    {"amanda": "partner_dept_name", "knack": "field_342"},
+    {"amanda": "folder_id", "knack": "field_355"},
 ]

--- a/knack_load_fees.py
+++ b/knack_load_fees.py
@@ -146,12 +146,15 @@ def main():
     logger.info(f"{len(reactiveate_rows_knack)} fee records to re-activate")
     logger.info(f"{len(delete_rows_knack)} to delete")
 
+    errors = []
+
     for row in new_rows_knack:
         try:
             app.record(method="create", obj=KNACK_OBJECT, data=row)
         except requests.exceptions.HTTPError as e:
-            logger.error(e.response.text)
-            raise e
+            logger.warning(e.response.text)
+            errors.append(e.response.text)
+            continue
         logger.info(f"Created Account Bill RSN: {row['field_285']}")
 
     for row in delete_rows_knack:
@@ -169,6 +172,9 @@ def main():
             logger.error(e.response.text)
             raise e
         logger.info(f"Reactivated Knack row id {row['id']}")
+
+    if errors:
+        raise Exception(f"Script completed with {len(errors)} errors.")
 
 
 if __name__ == "__main__":

--- a/knack_load_fees.py
+++ b/knack_load_fees.py
@@ -91,6 +91,35 @@ def map_row(row):
     return new_row
 
 
+def is_dupe_row_error(res):
+    """Checks a Knack API `400` response to see if it's caused by a known issue of attempting
+    to insert duplicate records. There duplicate rows in our AMANDA data due to errors
+    in SQL query. See: https://github.com/cityofaustin/atd-data-tech/issues/10447.
+
+    The response JSON we're handling looks like this:
+    {
+        'errors':
+        [
+            {
+                'field': 'field_285',
+                'type': 'unique',
+                'message': 'Fee Number must be unique. "13646573" is already being used.'
+            }
+        ]
+    }
+
+    Args:
+        res (requests.models.Response): a requests Response object from a Knack API call
+
+    Returns:
+        Bool: true if the response error was caused by the known issue described above.
+    """
+    error = res.json()["errors"][0]
+    if error["type"] == "unique" and error["field"] == "field_285":
+        return True
+    else:
+        return False
+
 def main():
     logger.info("Instanciating Knack app...")
     app = knackpy.App(app_id=KNACK_APP_ID, api_key=KNACK_API_KEY)
@@ -146,15 +175,16 @@ def main():
     logger.info(f"{len(reactiveate_rows_knack)} fee records to re-activate")
     logger.info(f"{len(delete_rows_knack)} to delete")
 
-    errors = []
-
     for row in new_rows_knack:
         try:
             app.record(method="create", obj=KNACK_OBJECT, data=row)
         except requests.exceptions.HTTPError as e:
-            logger.warning(e.response.text)
-            errors.append(e.response.text)
-            continue
+            if e.response.status_code == 400 and is_dupe_row_error(e.response):
+                # ignore dupe row error
+                logger.warning("Row already exists - ignoring and moving on")
+                continue
+            else:
+                raise e
         logger.info(f"Created Account Bill RSN: {row['field_285']}")
 
     for row in delete_rows_knack:
@@ -172,9 +202,6 @@ def main():
             logger.error(e.response.text)
             raise e
         logger.info(f"Reactivated Knack row id {row['id']}")
-
-    if errors:
-        logger.error(f"Script completed with {len(errors)} errors.")
 
 
 if __name__ == "__main__":

--- a/knack_load_fees.py
+++ b/knack_load_fees.py
@@ -174,7 +174,7 @@ def main():
         logger.info(f"Reactivated Knack row id {row['id']}")
 
     if errors:
-        raise Exception(f"Script completed with {len(errors)} errors.")
+        logger.error(f"Script completed with {len(errors)} errors.")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Does not fix https://github.com/cityofaustin/atd-data-tech/issues/10447

This PR updates the fee loader script to so that it keeps going if a fee insert fails. This will cause the script to ignore duplicate records. It does not fix the underlying problem with our AMANDA query.

