### PR TITLE
Upgrade docker build/push actions 

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -3,7 +3,8 @@ name: Docker Image CI
 
 on:
   push:
-    branches: [production, staging]
+    branches:
+      - production
 
 jobs:
   main:
@@ -23,7 +24,6 @@ jobs:
           push: true
           tags: |
             ${{ secrets.DOCKER_USERNAME }}/atd-cost-of-service:production
-            ${{ secrets.DOCKER_USERNAME }}/atd-cost-of-service:staging
             ${{ secrets.DOCKER_USERNAME }}/atd-cost-of-service:latest
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -19,7 +19,7 @@ jobs:
           password: ${{ secrets.DOCKER_PASSWORD }}
       - name: Build and push
         id: docker_build
-        uses: ocker/build-push-action@v3
+        uses: docker/build-push-action@v3
         with:
           push: true
           tags: |

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -10,15 +10,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
       - name: Login to DockerHub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
       - name: Build and push
         id: docker_build
-        uses: docker/build-push-action@v2
+        uses: ocker/build-push-action@v3
         with:
           push: true
           tags: |


### PR DESCRIPTION
I noticed we're getting deprecation warnings in our docker action, e.g.: https://github.com/cityofaustin/atd-cost-of-service-reporting/actions/runs/3904142587/jobs/6669517884#step:2:16. This should clear that up.

We're also not using a staging branch so I removed references to it in the build action.

There's no way to test this, but I modeled it after https://github.com/cityofaustin/atd-knack-services/blob/production/.github/workflows/docker-image-build-push.yml.
