### PR TITLE
💪 #2: Build docker image for ARM64 in addition to existing X86_64

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -4,7 +4,7 @@ name: Docker Image CI
 on:
   push:
     branches:
-      # - production
+      - production
 
 jobs:
   build-image-and-push:
@@ -13,9 +13,9 @@ jobs:
       -
         name: Checkout
         uses: actions/checkout@v6 # https://github.com/marketplace/actions/checkout
-      # -
-      #   name: Set up QEMU
-      #   uses: docker/setup-qemu-action@v4 # https://github.com/marketplace/actions/docker-setup-qemu
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v4 # https://github.com/marketplace/actions/docker-setup-qemu
       -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4 # https://github.com/marketplace/actions/docker-setup-buildx
@@ -32,8 +32,8 @@ jobs:
         with:
           push: true
           platforms: linux/amd64,linux/arm64
-            #${{ secrets.DOCKER_USERNAME }}/atd-cost-of-service:production
           tags: |
+            ${{ secrets.DOCKER_USERNAME }}/atd-cost-of-service:production
             ${{ secrets.DOCKER_USERNAME }}/atd-cost-of-service:latest
       -
         name: Image digest

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -4,7 +4,7 @@ name: Docker Image CI
 on:
   push:
     branches:
-      # - production
+      - production
 
 jobs:
   build-image-and-push:
@@ -32,8 +32,8 @@ jobs:
         with:
           push: true
           platforms: linux/amd64,linux/arm64
-            # ${{ secrets.DOCKER_USERNAME }}/atd-cost-of-service:production
           tags: |
+            ${{ secrets.DOCKER_USERNAME }}/atd-cost-of-service:production
             ${{ secrets.DOCKER_USERNAME }}/atd-cost-of-service:latest
       -
         name: Image digest

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -1,29 +1,40 @@
-# Build and push docker image with production **and** staging tags
+# Build and push multi-arch Docker image (amd64 + arm64 / Apple Silicon) with production and latest tags
 name: Docker Image CI
 
 on:
   push:
     branches:
-      - production
+      # - production
 
 jobs:
-  main:
+  build-image-and-push:
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-      - name: Login to DockerHub
-        uses: docker/login-action@v2
+      -
+        name: Checkout
+        uses: actions/checkout@v6 # https://github.com/marketplace/actions/checkout
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v4 # https://github.com/marketplace/actions/docker-setup-qemu
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4 # https://github.com/marketplace/actions/docker-setup-buildx
+      -
+        name: Login to DockerHub
+        uses: docker/login-action@v4 # https://github.com/marketplace/actions/docker-login
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-      - name: Build and push
+      -
+        name: Build and push
         id: docker_build
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v7 # https://github.com/marketplace/actions/build-and-push-docker-images
         with:
           push: true
+          platforms: linux/amd64,linux/arm64
+            # ${{ secrets.DOCKER_USERNAME }}/atd-cost-of-service:production
           tags: |
-            ${{ secrets.DOCKER_USERNAME }}/atd-cost-of-service:production
             ${{ secrets.DOCKER_USERNAME }}/atd-cost-of-service:latest
-      - name: Image digest
+      -
+        name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -4,7 +4,7 @@ name: Docker Image CI
 on:
   push:
     branches:
-      - production
+      # - production
 
 jobs:
   build-image-and-push:
@@ -13,9 +13,9 @@ jobs:
       -
         name: Checkout
         uses: actions/checkout@v6 # https://github.com/marketplace/actions/checkout
-      -
-        name: Set up QEMU
-        uses: docker/setup-qemu-action@v4 # https://github.com/marketplace/actions/docker-setup-qemu
+      # -
+      #   name: Set up QEMU
+      #   uses: docker/setup-qemu-action@v4 # https://github.com/marketplace/actions/docker-setup-qemu
       -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4 # https://github.com/marketplace/actions/docker-setup-buildx
@@ -32,8 +32,8 @@ jobs:
         with:
           push: true
           platforms: linux/amd64,linux/arm64
+            #${{ secrets.DOCKER_USERNAME }}/atd-cost-of-service:production
           tags: |
-            ${{ secrets.DOCKER_USERNAME }}/atd-cost-of-service:production
             ${{ secrets.DOCKER_USERNAME }}/atd-cost-of-service:latest
       -
         name: Image digest


### PR DESCRIPTION
## 2️⃣ 

This is the second PR of this nature today. They are almost identical. Here's the other [one](https://github.com/cityofaustin/atd-road-conditions/pull/6).

## Issue 

None-ish, but kinda https://github.com/cityofaustin/atd-data-tech/issues/25457.

## Rational

In the course of porting a DAG to v3, I found that I needed this to be a multi-arch image to test on my mac. 

## Testing

To test this, please read the diff and please observe [this execution of this workflow](https://github.com/cityofaustin/atd-cost-of-service-reporting/actions/runs/23867624747). If you observe that it worked, then ✅.
